### PR TITLE
On OS X the GNU libtool is prefixed with a g.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 # Run this to generate all the initial makefiles, etc.
 
-LIBTOOLIZE=${LIBTOOLIZE:-libtoolize}
+if which glibtoolize >/dev/null 2>&1; then
+  LIBTOOLIZE=${LIBTOOLIZE:-glibtoolize}
+else
+  LIBTOOLIZE=${LIBTOOLIZE:-libtoolize}
+fi
 LIBTOOLIZE_FLAGS="--copy --force"
 ACLOCAL=${ACLOCAL:-aclocal}
 AUTOHEADER=${AUTOHEADER:-autoheader}


### PR DESCRIPTION
Fixes one of the issues when trying to build on OS X.
