### PR TITLE
[dirlisting] Add dark mode support

### DIFF
--- a/src/modules/mod_dirlist.c
+++ b/src/modules/mod_dirlist.c
@@ -80,7 +80,15 @@ static const gchar html_css[] =
 	"	div#footer { font: 90% monospace; color: #787878; padding-top: 4px; }\n"
 	"	a.sortheader { color: black; text-decoration: none; display: block; }\n"
 	"	span.sortarrow { text-decoration: none; }\n"
-	"</style>\n";
+	"	@media (prefers-color-scheme: dark) {\n"
+	"		a, a:active { color: #9E9EFF; }\n"
+	"		a:visited { color: #D0ADF0; }\n"
+	"		body, #dirlist { background-color: transparent; }\n"
+	"		div#footer { color: #878787; }\n"
+	"		a.sortheader { color: white; }\n"
+	"	}\n"
+	"</style>\n"
+	"<meta name=\"color-scheme\" content=\"light dark\">\n";
 
 static const gchar javascript_sort[] =
 	"<script type=\"text/javascript\">\n"


### PR DESCRIPTION
This adds dark mode support to lighttpd's dirlisting generated pages.

Nowadays files transferred to browser via text/* MIME are also getting automatic dark mode by the browsers so this makes lighttpd's dirlisting compatible with those features of the browsers.

https://github.com/lighttpd/lighttpd2/assets/833473/71c67725-6fe8-4da0-810b-b8be708e39b4

lighttpd 1.4 version of the patch: https://github.com/lighttpd/lighttpd1.4/pull/134

(build instruction self note for future)
```
meson setup --buildtype debugoptimized build # currently with -Dlua=false due to a compile issue
cp contrib/lighttpd.conf .. # then edit it
ninja -C build && (cd .. && lighttpd2/build/src/main/lighttpd2-worker -m lighttpd2/build/src/modules/)
```